### PR TITLE
当前控制器如果为根控制器，不让手势执行。不然，在根控制器进行滑动返回的手势操作后，页面会假性卡死。

### DIFF
--- a/YLFullscreenSliderDemo/YLFullscreenSliderDemo/YLFullscreenSlider/YLFullscreenSliderController.swift
+++ b/YLFullscreenSliderDemo/YLFullscreenSliderDemo/YLFullscreenSlider/YLFullscreenSliderController.swift
@@ -38,8 +38,15 @@ class YLFullscreenSliderController: UINavigationController {
 
         //4 创建自己的手势pan
         let panGes = UIPanGestureRecognizer()
+        panGes.delegate = self
         gesView.addGestureRecognizer(panGes)
         panGes.addTarget(target, action: action)
 
+    }
+}
+
+extension YLFullscreenSliderController: UIGestureRecognizerDelegate {
+    func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+        return self.viewControllers.count != 1
     }
 }


### PR DESCRIPTION
作者你好，如果当前控制器如果为根控制器，在根控制器进行滑动返回的手势操作后，页面会假性卡死。我添加了手势的代理方法，在 gestureRecognizerShouldBegin 里判断如果是根控制器，不让手势执行。